### PR TITLE
missing dependency for expect.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "biggulp": "0.*.*",
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
+    "expect.js": "^0.3.1",
     "gulp": "~3.8.1",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^3.0.0"


### PR DESCRIPTION
When I tried running `npm test` I got a complaint about missing expect.js - Installed as a dev-dependency